### PR TITLE
test: Add UI tests

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,9 +31,18 @@ export function activate(context: vscode.ExtensionContext) {
 
   // 	logger.info({ level: 'info', message: "Congrats, todoer is active!" })
 
-  const toggleTaskCmd = vscode.commands.registerCommand("todoer.toggleTask", createCommand(todoer.toggleTask));
-  const toggleDoneCmd = vscode.commands.registerCommand("todoer.toggleDone", createCommand(todoer.toggleComplete));
-  const toggleCancelCmd = vscode.commands.registerCommand("todoer.toggleCancel", createCommand(todoer.toggleCancel));
+  const toggleTaskCmd = vscode.commands.registerCommand(
+    "todoer.toggleTask",
+    createCommand(todoer.toggleTask)
+  );
+  const toggleDoneCmd = vscode.commands.registerCommand(
+    "todoer.toggleDone",
+    createCommand(todoer.toggleComplete)
+  );
+  const toggleCancelCmd = vscode.commands.registerCommand(
+    "todoer.toggleCancel",
+    createCommand(todoer.toggleCancel)
+  );
 
   context.subscriptions.push(toggleTaskCmd);
   context.subscriptions.push(toggleDoneCmd);

--- a/test/acceptance/suite/extension.test.ts
+++ b/test/acceptance/suite/extension.test.ts
@@ -1,3 +1,4 @@
+import { SilentReporter } from "@vscode/test-electron";
 import * as assert from "assert";
 
 // You can import and use all API from the 'vscode' module
@@ -6,10 +7,119 @@ import * as vscode from "vscode";
 // import * as myExtension from '../../extension';
 
 suite("Extension Test Suite", () => {
-  vscode.window.showInformationMessage("Start all tests.");
+  // Make sure there is an active editor
+  suiteSetup(async () => {
+    await vscode.commands.executeCommand(
+      "workbench.action.files.newUntitledFile"
+    );
+  });
 
-  test("Sample test", () => {
-    assert.strictEqual(-1, [1, 2, 3].indexOf(5));
-    assert.strictEqual(-1, [1, 2, 3].indexOf(0));
+  // Clear the contents of the active text editor before each test
+  setup(async () => {
+    const editor = getEditor();
+    const document = editor.document;
+    vscode.window.showTextDocument;
+
+    await editor.edit((edit) => {
+      edit.delete(
+        new vscode.Range(
+          new vscode.Position(0, 0),
+          new vscode.Position(document.lineCount + 1, 0)
+        )
+      );
+    });
+  });
+
+  test("Creating a task", async () => {
+    // Given some text is entered
+    const editor = getEditor();
+    await editor.edit((edit) => {
+      edit.insert(new vscode.Position(0, 0), "Go shopping");
+    });
+
+    // When I create a task
+    await vscode.commands.executeCommand("todoer.toggleTask");
+    await wait(200);
+
+    // Then a task is created
+    assert.strictEqual(editor.document.getText(), "- [ ] Go shopping");
+  });
+
+  test("Cancelling a task", async () => {
+    // Given a task has been created
+    const editor = getEditor();
+    await editor.edit((edit) => {
+      edit.insert(new vscode.Position(0, 0), "Go shopping");
+    });
+    await vscode.commands.executeCommand("todoer.toggleTask");
+    await wait(200);
+    assert.strictEqual(editor.document.getText(), "- [ ] Go shopping");
+
+    // When I cancel the task
+    await vscode.commands.executeCommand("todoer.toggleCancel");
+    await wait(200);
+
+    // Then the task is cancelled
+    assert.strictEqual(editor.document.getText(), "- [ ] ~~Go shopping~~");
+  });
+
+  test("Completing a task", async () => {
+    // Given a task has been created
+    const editor = getEditor();
+    await editor.edit((edit) => {
+      edit.insert(new vscode.Position(0, 0), "Go shopping");
+    });
+    await vscode.commands.executeCommand("todoer.toggleTask");
+    await wait(200);
+    assert.strictEqual(editor.document.getText(), "- [ ] Go shopping");
+
+    // When I complete the task
+    await vscode.commands.executeCommand("todoer.toggleDone");
+    await wait(200);
+
+    // Then the task is completed
+    assert.strictEqual(editor.document.getText(), "- [x] Go shopping");
+  });
+
+  test("Multiple lines", async () => {
+    // Given a multi-line selection
+    const editor = getEditor();
+    await editor.edit((edit) => {
+      edit.insert(new vscode.Position(0, 0), "Go shopping\nGo running");
+    });
+    await wait(200);
+
+    // When I select both of them and create a task
+    await vscode.commands.executeCommand("cursorMove", {
+      to: "up",
+      by: "line",
+      select: true,
+    });
+    await vscode.commands.executeCommand("todoer.toggleTask");
+    await wait(200);
+
+    // Then both lines have been turned into tasks
+    assert.strictEqual(
+      editor.document.getText(),
+      "- [ ] Go shopping\n- [ ] Go running"
+    );
   });
 });
+
+// I've observed that calling `editor.document.getText()` right after calling
+// `await vscode.commands.executeCommand()`, I still get the old text before
+// formatting.  I'm not sure why.  Adding a slight sleep in between these
+// calls seems to fix the test flakiness.
+async function wait(ms: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(() => resolve(), ms);
+  });
+}
+
+function getEditor() {
+  let editor = vscode.window.activeTextEditor;
+  if (!editor) {
+    throw new Error("Expected to get a vscode.TextEditor, but got undefined");
+  }
+  return editor;
+}


### PR DESCRIPTION
These tests are successful when run through the "F5" button/vscode
debugger, but are not successfull when you run the `npm run test:acceptance`
script.  I think it has to do something with the out/ directory not
containing the package.json file and maybe other necessary vscode
extension files.

#12